### PR TITLE
ci: add permissions to write images

### DIFF
--- a/.github/workflows/ghcr.yaml
+++ b/.github/workflows/ghcr.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'release/*'
 
 permissions:
   contents: read
@@ -16,6 +17,13 @@ jobs:
   ghcr_publish:
     name: "Publish Docker Image to GHCR"
     runs-on: ubuntu-latest
+
+    # Requires write permissions to packages, attestations, and id-token for pushing to GHCR.
+    permissions:
+      packages: write
+      attestations: write
+      id-token: write
+
     steps:
         - name: Checkout repository
           uses: actions/checkout@v4


### PR DESCRIPTION
I missed some permissions that allows the action to write on GHCR.

Added at the job level.
